### PR TITLE
Loosen Gemspec

### DIFF
--- a/sidekiq-global_id.gemspec
+++ b/sidekiq-global_id.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "globalid"
-  spec.add_dependency "sidekiq", "~> 6.0"
+  spec.add_dependency "sidekiq", "~> 7.0"
 
   spec.add_development_dependency "appraisal"
 end

--- a/test/support/sidekiq.rb
+++ b/test/support/sidekiq.rb
@@ -3,12 +3,16 @@
 require "sidekiq"
 require "sidekiq/testing"
 
-Sidekiq.client_middleware do |chain|
-  chain.add Sidekiq::GlobalID::ClientMiddleware
+Sidekiq.configure_client do |config|
+  config.client_middleware do |chain|
+    chain.add Sidekiq::GlobalID::ClientMiddleware
+  end
 end
 
-Sidekiq.server_middleware do |chain|
-  chain.add Sidekiq::GlobalID::ServerMiddleware
+Sidekiq.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add Sidekiq::GlobalID::ServerMiddleware
+  end
 end
 
 Sidekiq::Testing.fake!


### PR DESCRIPTION
To upgrade to Rails 7.1 we must upgrade to Sidekiq 7.x, so this is the first step in making this gem compatible.