### PR TITLE
Fix cattr serialization for ActiveJob jobs

### DIFF
--- a/lib/sidekiq/global_id/client_middleware.rb
+++ b/lib/sidekiq/global_id/client_middleware.rb
@@ -25,10 +25,10 @@ module Sidekiq
         # ActiveJob has its own serialization mechanism for GlobalID
         unless active_job?(job)
           job["args"].map!(&:serialize)
+        end
 
-          if job.key?("cattr")
-            job["cattr"] = job["cattr"].dup&.serialize
-          end
+        if job.key?("cattr")
+          job["cattr"] = job["cattr"].dup&.serialize
         end
 
         yield

--- a/lib/sidekiq/global_id/server_middleware.rb
+++ b/lib/sidekiq/global_id/server_middleware.rb
@@ -24,10 +24,10 @@ module Sidekiq
         # ActiveJob has its own serialization mechanism for GlobalID
         unless active_job?(job)
           job["args"].map!(&:deserialize)
+        end
 
-          if job.key?("cattr")
-            job["cattr"] = job["cattr"]&.deserialize
-          end
+        if job.key?("cattr")
+          job["cattr"] = job["cattr"]&.deserialize
         end
 
         yield

--- a/test/sidekiq/global_id/client_middleware_test.rb
+++ b/test/sidekiq/global_id/client_middleware_test.rb
@@ -61,12 +61,75 @@ module Sidekiq
         assert options.key?(String(user.to_global_id))
       end
 
+      def test_serializing_cattr
+        job = { "args" => ["test"], "cattr" => { "current_user" => user } }
+
+        call_middleware(job)
+
+        assert job["cattr"]["current_user"].start_with?("gid://")
+      end
+
+      def test_cattr_does_not_mutate_original_hash
+        original_cattr = { "current_user" => user }
+        job = { "args" => ["test"], "cattr" => original_cattr }
+
+        call_middleware(job)
+
+        assert_equal user, original_cattr["current_user"]
+      end
+
+      def test_no_error_when_cattr_absent
+        job = { "args" => ["test"] }
+
+        call_middleware(job)
+
+        refute job.key?("cattr")
+      end
+
+      def test_skipping_args_serialization_for_active_job
+        job = {
+          "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+          "args" => [String(user.to_gid)]
+        }
+        original_args = job["args"].dup
+
+        call_middleware(job)
+
+        assert_equal original_args, job["args"]
+      end
+
+      def test_serializing_cattr_for_active_job
+        job = {
+          "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+          "args" => [String(user.to_gid)],
+          "cattr" => { "current_user" => user }
+        }
+
+        call_middleware(job)
+
+        assert job["cattr"]["current_user"].start_with?("gid://"),
+          "cattr should be serialized even for ActiveJob jobs"
+      end
+
+      def test_yields_to_next_middleware
+        job = { "args" => [] }
+        yielded = false
+
+        ClientMiddleware.new.call("TestWorker", job, "default", nil) { yielded = true }
+
+        assert yielded
+      end
+
       private
 
       def enqueue(*args)
         assert_change -> { TestWorker.jobs.size }, from: 0, to: 1 do
           TestWorker.perform_async(*args)
         end
+      end
+
+      def call_middleware(job)
+        ClientMiddleware.new.call("TestWorker", job, "default", nil) {}
       end
     end
   end

--- a/test/sidekiq/global_id/server_middleware_test.rb
+++ b/test/sidekiq/global_id/server_middleware_test.rb
@@ -58,6 +58,61 @@ module Sidekiq
         assert opts.key?(user)
       end
 
+      def test_deserializing_cattr
+        gid = String(user.to_gid)
+        job = { "args" => ["test"], "cattr" => { "current_user" => gid } }
+
+        call_middleware(job)
+
+        assert_equal user, job["cattr"]["current_user"]
+      end
+
+      def test_no_error_when_cattr_absent
+        job = { "args" => ["test"] }
+
+        call_middleware(job)
+
+        refute job.key?("cattr")
+      end
+
+      def test_skipping_args_deserialization_for_active_job
+        gid = String(user.to_gid)
+        job = {
+          "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+          "args" => [gid]
+        }
+
+        call_middleware(job)
+
+        assert_equal gid, job["args"].first,
+          "args should not be deserialized for ActiveJob jobs"
+      end
+
+      def test_deserializing_cattr_for_active_job
+        gid = String(user.to_gid)
+        job = {
+          "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+          "args" => [gid],
+          "cattr" => { "current_user" => gid }
+        }
+
+        call_middleware(job)
+
+        assert_equal gid, job["args"].first,
+          "args should not be deserialized for ActiveJob jobs"
+        assert_equal user, job["cattr"]["current_user"],
+          "cattr should be deserialized even for ActiveJob jobs"
+      end
+
+      def test_yields_to_next_middleware
+        job = { "args" => [] }
+        yielded = false
+
+        middleware.call("MyWorker", job, "default") { yielded = true }
+
+        assert yielded
+      end
+
       def call_middleware(job)
         middleware.call("MyWorker", job, "default", &-> {})
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ begin
 rescue LoadError # rubocop:disable Lint/SuppressedException
 end
 
+require "cgi"
 require "sidekiq/global_id"
 
 require_relative "support/assertions"


### PR DESCRIPTION
## Summary
- **Fix cattr handling**: Moved `cattr` (CurrentAttributes) serialization/deserialization outside the `unless active_job?` guard so it applies to all jobs, including ActiveJob. ActiveJob handles its own arg serialization but not CurrentAttributes.


🤖 Generated with [Claude Code](https://claude.com/claude-code)